### PR TITLE
Decorator to generate a NoCache() function variant

### DIFF
--- a/src/lib/Cachette.ts
+++ b/src/lib/Cachette.ts
@@ -141,6 +141,9 @@ export namespace Cachette {
         const fetchFunction = origFunction.bind(this, ...args);
         return getOrFetchValue(key, ttl, fetchFunction);
       };
+
+      // create a NoCache version
+      target[`${propertyKey}NoCache`] = origFunction;
       descriptor.value = newFunction;
       return descriptor;
     };

--- a/test/Cachette_test.ts
+++ b/test/Cachette_test.ts
@@ -311,6 +311,17 @@ describe('Cachette', () => {
       expect(numSuccess).to.eql(100);
     });
 
+    it('creates a NoCache() variant', async () => {
+      const myObj = new MyClass();
+
+      await myObj.fetchSomething('123');
+      await myObj.fetchSomething('123');
+      expect(myObj.numCalled).to.eql(1);
+
+      await myObj['fetchSomethingNoCache']('123');
+      expect(myObj.numCalled).to.eql(2);
+    });
+
   });
 
 });


### PR DESCRIPTION
Sometimes, one will want to force bypassing the cache to get the real value. To that end, the decorator no adds a new method to the class, adding the suffix NoCache to the original function name. Unfortunately, that function won't be accessible directly through the dot-notation in TypeScript.

I added a unit test