### PR TITLE
Clearing cached function call

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.1.0",
     "pre-commit": "^1.2.2",
-    "remap-istanbul": "^0.8.4",
+    "remap-istanbul": "^0.10.1",
     "sinon": "^1.17.6",
     "source-map-support": "^0.4.8",
     "tslint": "^4.5.1",

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -40,4 +40,22 @@ export abstract class CacheClient {
     return this[functionName].bind(this);
   }
 
+  /**
+   * Clears the valued returned from a cached function call,
+   * using the CacheClient.cached.
+   */
+  public async clearCachedFunctionCall(functionName: string, ...args: any[]): Promise<void> {
+    const key = this.buildCacheKey(functionName, args);
+    await this.cacheInstance.delValue(key);
+  }
+
+  /**
+   * Gets the valued returned from a cached function call,
+   * using the CacheClient.cached.
+   */
+  public async getCachedFunctionCall(functionName: string, ...args: any[]): Promise<CachableValue> {
+    const key = this.buildCacheKey(functionName, args);
+    return this.cacheInstance.getValue(key);
+  }
+
 }

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -62,6 +62,19 @@ describe('CacheClient', () => {
       expect(myObj.numCalled).to.eql(2);
     });
 
+    it('can clear the value of a function that was cached using the decorator.', async () => {
+      const myObj = new MyClass();
+
+      await myObj.fetchSomething('123');
+      expect(myObj.numCalled).to.eql(1);
+      let cachedValue = await myObj.getCachedFunctionCall('fetchSomething', '123');
+      expect(cachedValue).to.exist;
+
+      await myObj.clearCachedFunctionCall('fetchSomething', '123');
+      cachedValue = await myObj.getCachedFunctionCall('fetchSomething', '123');
+      expect(cachedValue).not.to.exist;
+    });
+
   });
 
   describe('buildCacheKey', () => {


### PR DESCRIPTION
This removes the need to craft the cache key from the client side.