### PR TITLE
Publish typings in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "description": "Resilient cache library supporting concurrent requests through local cache or Redis.",
   "main": "dist/src/index.js",
+  "typings": "dist/src/index.d.ts",
   "repository": "https://github.com/unitoio/cachette",
   "author": {
     "name": "Unito",


### PR DESCRIPTION
To be usable, the TS typing file must be present in package.json