### PR TITLE
WriteThroughCache: Fix TTL when local cache is refreshed

### DIFF
--- a/src/lib/CacheInstance.ts
+++ b/src/lib/CacheInstance.ts
@@ -7,6 +7,11 @@ export type FetchingFunction = () => Promise<CachableValue>;
 export abstract class CacheInstance extends EventEmitter {
 
   /**
+   * Function that can be awaited for the cache instance connection to be ready.
+   */
+  public abstract isReady(): Promise<void>;
+
+  /**
    * Get a value from the cache.
    *
    * @param key   The key of the value to get.
@@ -16,6 +21,17 @@ export abstract class CacheInstance extends EventEmitter {
    *
    */
   public abstract getValue(key: string): Promise<CachableValue>;
+
+  /**
+   * Get the TTL of an entry, in ms
+   *
+   * @param key   The key of the entry whose ttl to retrieve
+   *
+   * @return      The remaining TTL on the entry, in ms.
+   *              undefined if the entry does not exist.
+   *              0 if the entry does not expire.
+   */
+  public abstract getTtl(key: string): Promise<number | undefined>;
 
   /**
    * Set a value in the cache.

--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -15,6 +15,13 @@ export class LocalCache extends CacheInstance {
   /**
    * @inheritdoc
    */
+  public async isReady(): Promise<void> {
+    return;
+  }
+
+  /**
+   * @inheritdoc
+   */
   public async setValue(key: string, value: CachableValue, ttl: number = 0): Promise<boolean> {
     this.emit('set', key, value);
 
@@ -39,6 +46,13 @@ export class LocalCache extends CacheInstance {
     const value = await this.cache.get(key);
     this.emit('get', key, value);
     return value;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async getTtl(key: string): Promise<number | undefined> {
+    throw new Error('not implemented');
   }
 
   /**

--- a/src/lib/RedisCache.ts
+++ b/src/lib/RedisCache.ts
@@ -302,7 +302,7 @@ export class RedisCache extends CacheInstance {
       return ttl;
     } catch (error) {
       this.emit('warn', 'Error while fetching ttl from the Redis cache', error);
-      return -1;
+      return undefined;
     }
   }
 

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -50,8 +50,11 @@ export class WriteThroughCache extends CacheInstance {
     if (localValue !== undefined) {
       return localValue;
     }
-    const ttl = await this.redisCache.getTtl(key);
-    const redisValue = await this.redisCache.getValue(key);
+    const [redisValue, ttl] = await Promise.all([
+      this.redisCache.getValue(key),
+      this.redisCache.getTtl(key),
+    ]);
+
     if (redisValue !== undefined && ttl !== undefined) {
       await this.localCache.setValue(key, redisValue, ttl / 1000);
     }

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -26,6 +26,13 @@ export class WriteThroughCache extends CacheInstance {
   /**
    * @inheritdoc
    */
+  public async isReady(): Promise<void> {
+    return this.redisCache.isReady();
+  }
+
+  /**
+   * @inheritdoc
+   */
   public async setValue(
     key: string,
     value: CachableValue,
@@ -43,11 +50,19 @@ export class WriteThroughCache extends CacheInstance {
     if (localValue !== undefined) {
       return localValue;
     }
+    const ttl = await this.redisCache.getTtl(key);
     const redisValue = await this.redisCache.getValue(key);
-    if (redisValue !== undefined) {
-      await this.localCache.setValue(key, redisValue, 120);
+    if (redisValue !== undefined && ttl !== undefined) {
+      await this.localCache.setValue(key, redisValue, ttl / 1000);
     }
     return redisValue;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async getTtl(key: string): Promise<number | undefined> {
+    return this.redisCache.getTtl(key);
   }
 
   /**


### PR DESCRIPTION
When the local cache was refreshed from a redis value, it always set the hardcoded value of 120s as the TTL.