### PR TITLE
⚙️ Adding max age setting for local cache

### DIFF
--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -5,10 +5,15 @@ import { CachableValue, CacheInstance } from './CacheInstance';
 
 export class LocalCache extends CacheInstance {
 
-  public static MAXIMUM_CACHE_SIZE: number = 5000;
+  public static DEFAULT_MAX_ITEMS: number = 5000;
+  // Default maximum age for the items, in MS.
+  public static DEFAULT_MAX_AGE: number = 30 * 60 * 1000;
 
+  // See https://github.com/isaacs/node-lru-cache#options
+  // for options.
   private cache: any = new LRU({
-    max: LocalCache.MAXIMUM_CACHE_SIZE,
+    max: Number.parseInt(process.env.CACHETTE_LC_MAX_ITEMS, 10) || LocalCache.DEFAULT_MAX_ITEMS,
+    maxAge: Number.parseInt(process.env.CACHETTE_LC_MAX_AGE, 10) || LocalCache.DEFAULT_MAX_AGE,
     stale: false,
   });
 

--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -12,8 +12,8 @@ export class LocalCache extends CacheInstance {
   // See https://github.com/isaacs/node-lru-cache#options
   // for options.
   private cache: any = new LRU({
-    max: Number.parseInt(process.env.CACHETTE_LC_MAX_ITEMS, 10) || LocalCache.DEFAULT_MAX_ITEMS,
-    maxAge: Number.parseInt(process.env.CACHETTE_LC_MAX_AGE, 10) || LocalCache.DEFAULT_MAX_AGE,
+    max: Number.parseInt(process.env.CACHETTE_LC_MAX_ITEMS as string, 10) || LocalCache.DEFAULT_MAX_ITEMS,
+    maxAge: Number.parseInt(process.env.CACHETTE_LC_MAX_AGE as string, 10) || LocalCache.DEFAULT_MAX_AGE,
     stale: false,
   });
 

--- a/test/LocalCache_test.ts
+++ b/test/LocalCache_test.ts
@@ -47,8 +47,8 @@ describe('LocalCache', () => {
   });
 
   it('will not grow in size past the maximum size', async () => {
-    const origMax = LocalCache['MAXIMUM_CACHE_SIZE'];
-    LocalCache['MAXIMUM_CACHE_SIZE'] = 5;
+    const origMax = LocalCache['DEFAULT_MAX_ITEMS'];
+    LocalCache['DEFAULT_MAX_ITEMS'] = 5;
 
     const cache = new LocalCache();
     await cache.setValue('1', '1');
@@ -57,6 +57,8 @@ describe('LocalCache', () => {
     await cache.setValue('4', '4');
     await cache.setValue('5', '5');
     await cache.setValue('6', '6');
+    await cache.setValue('7', '7');
+    await cache.setValue('8', '8');
 
     const cacheSize = cache['cache'].length;
     expect(cacheSize).to.equal(5);
@@ -65,7 +67,7 @@ describe('LocalCache', () => {
     expect(oldestValue).to.equal(undefined);
 
     // restore
-    LocalCache['MAXIMUM_CACHE_SIZE'] = origMax;
+    LocalCache['DEFAULT_MAX_ITEMS'] = origMax;
 
   });
 


### PR DESCRIPTION
This adds a default `maxAge` to the local cache, and maps some options to environment variables, so that we can experiment easily.