### PR TITLE
allow clearing only in-memory items.

### DIFF
--- a/src/lib/CacheInstance.ts
+++ b/src/lib/CacheInstance.ts
@@ -60,6 +60,11 @@ export abstract class CacheInstance extends EventEmitter {
   public abstract clear(): Promise<void>;
 
   /**
+   * clear any in-memory cache item.
+   */
+  public abstract clearMemory(): Promise<void>;
+
+  /**
    * Determines if locking is supported in the cache implementation
    */
   public isLockingSupported(): boolean {

--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -62,7 +62,17 @@ export class LocalCache extends CacheInstance {
     this.cache.del(key);
   }
 
+  /**
+   * @inheritdoc
+   */
   public async clear(): Promise<void> {
+    this.cache.reset();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async clearMemory(): Promise<void> {
     this.cache.reset();
   }
 

--- a/src/lib/RedisCache.ts
+++ b/src/lib/RedisCache.ts
@@ -323,6 +323,13 @@ export class RedisCache extends CacheInstance {
 
   /**
    * @inheritdoc
+   */
+  public async clearMemory(): Promise<void> {
+    return;
+  }
+
+  /**
+   * @inheritdoc
    * Locking through the redlock algorithm
    * https://redis.io/topics/distlock
    */

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -85,6 +85,14 @@ export class WriteThroughCache extends CacheInstance {
     await this.redisCache.clear();
   }
 
+  /**
+   * @inheritdoc
+   */
+  public async clearMemory(): Promise<void> {
+    await this.localCache.clearMemory();
+    await this.redisCache.clearMemory();
+  }
+
   public isLockingSupported(): boolean {
     return true;
   }


### PR DESCRIPTION
I feel like this should be part of the abstraction too, considered that clearing all of the items in the redis cache seems radical