### PR TITLE
Add itemCount to Cache abstraction

### DIFF
--- a/src/lib/CacheInstance.ts
+++ b/src/lib/CacheInstance.ts
@@ -7,9 +7,14 @@ export type FetchingFunction = () => Promise<CachableValue>;
 export abstract class CacheInstance extends EventEmitter {
 
   /**
-   * Function that can be awaited for the cache instance connection to be ready.
+   * Will resolve when the cache instance connection is ready.
    */
   public abstract isReady(): Promise<void>;
+
+  /**
+   * Get the number of items in the cache.
+   */
+  public abstract itemCount(): Promise<number>;
 
   /**
    * Get a value from the cache.

--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -22,6 +22,13 @@ export class LocalCache extends CacheInstance {
   /**
    * @inheritdoc
    */
+  public async itemCount(): Promise<number> {
+    return this.cache.itemCount;
+  }
+
+  /**
+   * @inheritdoc
+   */
   public async setValue(key: string, value: CachableValue, ttl: number = 0): Promise<boolean> {
     this.emit('set', key, value);
 

--- a/src/lib/RedisCache.ts
+++ b/src/lib/RedisCache.ts
@@ -84,6 +84,13 @@ export class RedisCache extends CacheInstance {
   }
 
   /**
+   * @inheritdoc
+   */
+  public async itemCount(): Promise<number> {
+    return this.client.dbsizeAsync();
+  }
+
+  /**
    * The error event is emitted on stream error.
    * We must catch it, otherwise it will crash the process
    * with an UncaughtException.

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -33,6 +33,13 @@ export class WriteThroughCache extends CacheInstance {
   /**
    * @inheritdoc
    */
+  public async itemCount(): Promise<number> {
+    return await this.redisCache.itemCount() + await this.localCache.itemCount();
+  }
+
+  /**
+   * @inheritdoc
+   */
   public async setValue(
     key: string,
     value: CachableValue,

--- a/test/LocalCache_test.ts
+++ b/test/LocalCache_test.ts
@@ -10,15 +10,20 @@ describe('LocalCache', () => {
     const cache = new LocalCache();
     const wasSet = await cache.setValue('key', 'value');
     expect(wasSet).to.be.true;
+    expect(await cache.itemCount()).to.equal(1);
     const value = await cache.getValue('key');
     expect(value).to.equal('value');
+    expect(await cache.itemCount()).to.equal(1);
   });
 
   it('will not throw if we set a value of undefined', async () => {
     const cache = new LocalCache();
+    expect(await cache.itemCount()).to.equal(0);
     const wasSet = await cache.setValue('key', undefined);
+    expect(await cache.itemCount()).to.equal(0);
     expect(wasSet).to.be.false;
     const value = await cache.getValue('key');
+    expect(await cache.itemCount()).to.equal(0);
     expect(value).not.to.exist;
   });
 
@@ -58,7 +63,7 @@ describe('LocalCache', () => {
     await cache.setValue('5', '5');
     await cache.setValue('6', '6');
 
-    const cacheSize = cache['cache'].length;
+    const cacheSize = await cache.itemCount();
     expect(cacheSize).to.equal(5);
 
     const oldestValue = await cache.getValue('1');

--- a/test/RedisCache_test.ts
+++ b/test/RedisCache_test.ts
@@ -112,6 +112,28 @@ describe('RedisCache', () => {
 
   });
 
+  describe('itemCount', async () => {
+
+    it('can count the items in the redis cache.', async function (): Promise<void> {
+      if (!process.env.TEST_REDIS_URL) {
+        this.skip();
+      }
+
+      const cache = new RedisCache(process.env.TEST_REDIS_URL as string);
+      await cache.isReady();
+
+      // Just to be sure that the cache is really empty...
+      await cache.clear();
+
+      await cache.setValue('test1', 'value1');
+      await cache.setValue('test2', 'value2');
+      await cache.setValue('test3', 'value3');
+      expect(await cache.itemCount()).to.equal(3);
+      await cache.clear();
+      expect(await cache.itemCount()).to.equal(0);
+    });
+  });
+
   describe('constructor', () => {
     it('will not crash the application given an invalid Redis URL', async () => {
       const cache = new RedisCache('redis://localhost:9999');

--- a/test/WriteThroughCache_test.ts
+++ b/test/WriteThroughCache_test.ts
@@ -147,11 +147,13 @@ describe('WriteThroughCache', () => {
 
       const base = [...Array(10).keys()];
       await Promise.all(base.map(i => cache.setValue(`key${i}`, i)));
+      expect(await cache.itemCount()).to.equal(20);
 
       let values = await Promise.all(base.map(i => cache.getValue(`key${i}`)));
       expect(values.sort()).to.eql(base);
 
       await cache.clear();
+      expect(await cache.itemCount()).to.equal(0);
 
       values = await Promise.all(base.map(i => cache.getValue(`key${i}`)));
       values.forEach(value => expect(value).to.be.undefined);


### PR DESCRIPTION
This is to troubleshoot the memory usage of the local cache, before and after clearing the memory it uses.