### PR TITLE
🛠 Post-node10 fix: keep being able to pass specific tests to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "compile": "tsc",
     "prepublishOnly": "npm run clean && npm install && npm run compile",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "test": "npm run compile && nyc mocha",
-    "test:ci": "npm run compile && mkdir -p shippable/testresults shippable/codecoverage && nyc --reporter cobertura --report-dir shippable/codecoverage mocha -- --opts test/mocha.ci.opts",
+    "test": "npm run compile && nyc mocha 'dist/test/**/*.js'",
+    "test:ci": "npm run compile && mkdir -p shippable/testresults shippable/codecoverage && nyc --reporter cobertura --report-dir shippable/codecoverage mocha -- --opts test/mocha.ci.opts 'dist/test/**/*.js'",
     "packages:lock:regenerate": "rm -rf node_modules package-lock.json; npm install --package-lock; npm out; true"
   },
   "nyc": {

--- a/test/mocha.ci.opts
+++ b/test/mocha.ci.opts
@@ -7,4 +7,3 @@
 --reporter xunit
 --no-colors
 --reporter-options output=shippable/testresults/result.xml
-'dist/test/**/*.js'

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,4 +3,3 @@
 --require source-map-support/register
 --recursive
 --exit
-'dist/test/**/*.js'


### PR DESCRIPTION
Cannot override options in mocha.opts, https://github.com/mochajs/mocha/issues/1444

- https://github.com/unitoio/babylon-client/pull/47
- https://github.com/unitoio/backoff-decorator/pull/17
- https://github.com/unitoio/cachette/pull/32
- https://github.com/unitoio/connectors/pull/2588
- https://github.com/unitoio/keuf/pull/8
- https://github.com/unitoio/scheduler/pull/111
- https://github.com/unitoio/sync-worker/pull/1406
- https://github.com/unitoio/ucommon/pull/318
- https://github.com/unitoio/webhook-processor/pull/35
- https://github.com/unitoio/webhook-receiver/pull/43