### PR TITLE
📦 Bump redlock version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1548,9 +1548,9 @@
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "redlock": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redlock/-/redlock-3.1.2.tgz",
-      "integrity": "sha512-CKXhOvLd4In5QOfbcF0GIcSsa+pL9JPZd+eKeMk/Sydxh93NUNtwQMTIKFqwPu3PjEgDStwYFJTurVzNA33pZw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redlock/-/redlock-4.0.0.tgz",
+      "integrity": "sha512-971JQ2rBzZKIOrlqjjcEO4lbxmuq71QtfTNYk7w/m9h59mBYpN+r7xHZEWZw8ubEwvrxxzmqOl4fC2o05+UjDw==",
       "requires": {
         "bluebird": "^3.3.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,9 +181,9 @@
       "dev": true
     },
     "@types/redlock": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/redlock/-/redlock-3.0.5.tgz",
-      "integrity": "sha512-LhZ/zI7NQlqge+FEaWLDhL+P69qvhRCHJTQ6jEbMsmnjATMQOr3KJSED3UXbsmKJmhXoPlajR5EEyNHhsAE/Fw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/redlock/-/redlock-4.0.0.tgz",
+      "integrity": "sha512-kF8buBZkNgt9nIwTticRt6a1OR/lVUZ7uwnllW5DJN/i271Yj7BZ/eOP9MnOLV+UA+NhmP+jEgt2FNrfNcUU1A==",
       "requires": {
         "@types/bluebird": "*"
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@types/bluebird": "^3.0.36",
-    "@types/redlock": "^3.0.1",
+    "@types/redlock": "^4.0.0",
     "bluebird": "^3.5.5",
     "lru-cache": "^5.1.1",
     "redis": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,6 @@
     "bluebird": "^3.5.5",
     "lru-cache": "^5.1.1",
     "redis": "^2.8.0",
-    "redlock": "^3.1.2"
+    "redlock": "^4.0.0"
   }
 }


### PR DESCRIPTION
No release notes on the releases directly but there's only about 15 commits between 3.1.2 and 4.0.0
https://github.com/mike-marcacci/node-redlock/commits/master

their `ioredis` version was bumped from 3.0.0 to 4.10.0