### PR TITLE
✈️ migration to ioredis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,15 @@
       "integrity": "sha512-7qvf9F9tMTzo0akeswHPGqgUx/gIaJqrOEET/FCD8CFRkSUHlygQiM5yB6OvjrtdxBVLSyw7COJubsFYs0683g==",
       "dev": true
     },
+    "@types/ioredis": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.0.18.tgz",
+      "integrity": "sha512-iDIRGPGP4LwoeiKNxQcI38ZA5T8SC+MbGCiiNFJ+LNy9tdegj6f9PAZ7se4tiWJhUHbf25kEJt7k3YfmYjWKZg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -389,6 +398,11 @@
         }
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -532,6 +546,11 @@
         "object-keys": "^1.0.12"
       }
     },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -561,11 +580,6 @@
           "dev": true
         }
       }
-    },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -814,6 +828,40 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "ioredis": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.2.tgz",
+      "integrity": "sha512-B7st5okm4tixxlfbAvRWUcEhpCjnfqQ6uxYhEdLEndnFUsKOKgiarqkm5eIdFHN1/s8CCRs0GQhqY7E9ucZ+Ew==",
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.1.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "redis-commands": "1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "redis-parser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+          "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+          "requires": {
+            "redis-errors": "^1.0.0"
+          }
+        }
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1049,6 +1097,16 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -1163,8 +1221,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "neo-async": {
       "version": "2.6.1",
@@ -1527,25 +1584,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
-      "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
-      }
-    },
     "redis-commands": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
       "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
     },
-    "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
     },
     "redlock": {
       "version": "4.0.0",
@@ -1750,6 +1797,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "standard-as-callback": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.0.1.tgz",
+      "integrity": "sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg=="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "devDependencies": {
     "@types/chai": "^4.1.7",
+    "@types/ioredis": "^4.0.18",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.12",
     "@types/sinon": "^7.0.12",
@@ -72,8 +73,8 @@
     "@types/bluebird": "^3.0.36",
     "@types/redlock": "^4.0.0",
     "bluebird": "^3.5.5",
+    "ioredis": "^4.14.2",
     "lru-cache": "^5.1.1",
-    "redis": "^2.8.0",
     "redlock": "^4.0.0"
   }
 }

--- a/test/RedisCache_test.ts
+++ b/test/RedisCache_test.ts
@@ -5,60 +5,19 @@ import { RedisCache } from '../src/lib/RedisCache';
 
 describe('RedisCache', () => {
 
-  describe('buildSetArguments', () => {
-
-    it('can return only the key and the value', () => {
-      const setArguments = RedisCache.buildSetArguments('key', 'value');
-      expect(setArguments).to.eql(['key', 'value']);
+  describe('constructor', () => {
+    it('will not crash the application given an invalid Redis URL', async () => {
+      const cache = new RedisCache('redis://localhost:9999');
+      await cache.getValue('test');
+      await cache.setValue('test', 'value');
+      expect('still alive???').to.exist;
     });
 
-    it('will set the arguments when using time to live', () => {
-      const setArguments = RedisCache.buildSetArguments('key', 'value', 20);
-      expect(setArguments).to.eql(['key', 'value', 'EX', '20']);
+    it('will raise an error if given an Redis URL without protocol', async () => {
+      expect(
+        () => new RedisCache('rer17kq3qdwc5wmy.4gzf3f.ng.0001.use1.cache.amazonaws.com'),
+      ).to.throw();
     });
-
-    it('supports setting the time to live to 0', () => {
-      const setArguments = RedisCache.buildSetArguments('key', 'value', 0);
-      expect(setArguments).to.eql(['key', 'value']);
-    });
-
-    it('supports setting all the arguments at the same time', () => {
-      const setArguments = RedisCache.buildSetArguments('key', 'value', 14);
-      expect(setArguments).to.eql(['key', 'value', 'EX', '14']);
-    });
-
-  });
-
-  describe('retryStrategy', () => {
-
-    it('will not try to reconnect when it was never able to connect', () => {
-      const options = { times_connected: 0 };
-      const retryDirective = RedisCache.retryStrategy(options);
-      expect(typeof retryDirective).not.to.equal('number');
-      expect(retryDirective instanceof Error).to.be.true;
-      expect((<Error> retryDirective).message).to.include('Unable to connect');
-    });
-
-    it('will not try to reconnect when the maximum retry count has been reached', () => {
-      const options = { times_connected: 1, attempt: RedisCache.MAX_RETRY_COUNT + 1 };
-      const retryDirective = RedisCache.retryStrategy(options);
-      expect(typeof retryDirective).not.to.equal('number');
-      expect(retryDirective instanceof Error).to.be.true;
-      expect((<Error> retryDirective).message).to.include('connection attempts reached');
-    });
-
-    it('will try to reconnect when the maximum retry count has not been reached', () => {
-      const options = { times_connected: 1, attempt: 1 };
-      let retryDirective = RedisCache.retryStrategy(options);
-      expect(typeof retryDirective).to.equal('number');
-      expect(retryDirective).to.equal(RedisCache.RETRY_DELAY);
-
-      options.attempt = RedisCache.MAX_RETRY_COUNT;
-      retryDirective = RedisCache.retryStrategy(options);
-      expect(typeof retryDirective).to.equal('number');
-      expect(retryDirective).to.equal(RedisCache.RETRY_DELAY);
-    });
-
   });
 
   describe('value serialization', () => {
@@ -112,6 +71,53 @@ describe('RedisCache', () => {
 
   });
 
+  describe('setValue', async () => {
+    it('can set values', async function (): Promise<void> {
+      if (!process.env.TEST_REDIS_URL) {
+        this.skip();
+      }
+
+      const cache = new RedisCache(process.env.TEST_REDIS_URL as string);
+      await cache.isReady();
+
+      // Just to be sure that the cache is really empty...
+      await cache.clear();
+
+      const wasSet = await cache.setValue('key', 'value');
+      expect(wasSet).to.be.true;
+      expect(await cache.itemCount()).to.equal(1);
+      const value = await cache.getValue('key');
+      expect(value).to.equal('value');
+      expect(await cache.itemCount()).to.equal(1);
+    });
+
+    it('can set values with a TTL', async function (): Promise<void> {
+      if (!process.env.TEST_REDIS_URL) {
+        this.skip();
+      }
+
+      const cache = new RedisCache(process.env.TEST_REDIS_URL as string);
+      await cache.isReady();
+
+      // Just to be sure that the cache is really empty...
+      await cache.clear();
+
+      const wasSet = await cache.setValue('key', 'value', 30000);
+      expect(wasSet).to.be.true;
+
+      const value = await cache.getValue('key');
+      expect(value).to.equal('value');
+
+      expect(await cache.itemCount()).to.equal(1);
+
+      const ttl = await cache.getTtl('key');
+      expect(ttl).to.exist;
+      expect(ttl).to.be.above(0);
+      expect(ttl).to.be.below(30000000);
+    });
+
+  });
+
   describe('itemCount', async () => {
 
     it('can count the items in the redis cache.', async function (): Promise<void> {
@@ -131,21 +137,6 @@ describe('RedisCache', () => {
       expect(await cache.itemCount()).to.equal(3);
       await cache.clear();
       expect(await cache.itemCount()).to.equal(0);
-    });
-  });
-
-  describe('constructor', () => {
-    it('will not crash the application given an invalid Redis URL', async () => {
-      const cache = new RedisCache('redis://localhost:9999');
-      await cache.getValue('test');
-      await cache.setValue('test', 'value');
-      expect('still alive???').to.exist;
-    });
-
-    it('will raise an error if given an Redis URL without protocol', async () => {
-      expect(
-        () => new RedisCache('rer17kq3qdwc5wmy.4gzf3f.ng.0001.use1.cache.amazonaws.com'),
-      ).to.throw();
     });
   });
 


### PR DESCRIPTION
This was pretty straightforward as the interface of both libraries are similar. It's nice to have the typing with the new library, and it looks like it's more maintained than the one we were using until now. `ioredis` is also what we use in `keuf`, so it's easier to maintain our redis related codebase.

I also added some redis tests that will run when a redis test instance is available.

The retry strategy changed a bit. Now we're only setting the reconnection delay, and we're no longer detection if it's a first connection problem or a reconnection problem. Thoughts on that are welcome.

`redlock` supports both libraries, as mentioned [here](https://github.com/mike-marcacci/node-redlock#configuration)

For some reason the ttl when setting is in seconds, but is returned as msecs when getting the ttl of a value :thinking: 