### PR TITLE
use different redis connections for write/read operations to avoid landing all operation on the primary instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
-      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.6.tgz",
+      "integrity": "sha512-Sheg7yEJD51YHAvLEV/7Uvw95AeWqYPL3Vk3zGujJKIhJ+8oLw2ALaf3hbucILhKsgSoADOvtKRJuNVdcJkOrg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
+        "@babel/generator": "^7.8.6",
         "@babel/helpers": "^7.8.4",
-        "@babel/parser": "^7.8.4",
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.4",
-        "@babel/types": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -37,12 +37,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+      "integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3",
+        "@babel/types": "^7.8.6",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -100,43 +100,43 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+      "integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+      "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
+        "@babel/generator": "^7.8.6",
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.4",
-        "@babel/types": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+      "integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -199,9 +199,9 @@
       "dev": true
     },
     "@sinonjs/commons": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
-      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -240,9 +240,9 @@
       "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw=="
     },
     "@types/chai": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.8.tgz",
-      "integrity": "sha512-U1bQiWbln41Yo6EeHMr+34aUhvrMVyrhn9lYfPSpLTCrZlGxU4Rtn1bocX+0p2Fc/Jkd2FanCEXdw0WNfHHM0w==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.9.tgz",
+      "integrity": "sha512-NeXgZj+MFL4izGqA4sapdYzkzQG+MtGra9vhQ58dnmDY++VgJaRUws+aLVV5zRJCYJl/8s9IjMmhiUw1WsKSmw==",
       "dev": true
     },
     "@types/color-name": {
@@ -252,9 +252,9 @@
       "dev": true
     },
     "@types/ioredis": {
-      "version": "4.14.7",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.14.7.tgz",
-      "integrity": "sha512-PC0myxSTUm4m97YfD3Cn2s+7gajoUdM3Xh8JuULK7kftJOx7s3LfWWDPPVYAI96ADt+epQuu/qMa9yecIOL94A==",
+      "version": "4.14.8",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.14.8.tgz",
+      "integrity": "sha512-ww38Psb0jj/8h9UYjRuT9RYF46E5O3j+03XSEBx6OQvCIkgPV52kF8DshVLh8DMSZs3fEjeoEzmyM3KP9n53tQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -267,9 +267,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-      "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
+      "version": "12.12.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.28.tgz",
+      "integrity": "sha512-g73GJYJDXgf0jqg+P9S8h2acWbDXNkoCX8DLtJVu7Fkn788pzQ/oJsrdJz/2JejRf/SjfZaAhsw+3nd1D5EWGg==",
       "dev": true
     },
     "@types/redlock": {
@@ -281,9 +281,9 @@
       }
     },
     "@types/sinon": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
-      "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+      "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
       "dev": true
     },
     "aggregate-error": {
@@ -765,13 +765,13 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-      "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
+      "integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
-        "make-dir": "^3.0.0",
+        "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
       }
     },
@@ -909,9 +909,9 @@
       "dev": true
     },
     "hasha": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
-      "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+      "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
       "dev": true,
       "requires": {
         "is-stream": "^2.0.0",
@@ -959,9 +959,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.1.tgz",
-      "integrity": "sha512-94W+X//GHM+1GJvDk6JPc+8qlM7Dul+9K+lg3/aHixPN7ZGkW6qlvX0DG6At9hWtH2v3B32myfZqWoANUJYGJA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.16.0.tgz",
+      "integrity": "sha512-tlalhtuvnxXJNtrPjec1nGicuOCpi9ErYV/fRfwaWSzktX9ESrzHlcFwj1pVAL326E8dmt7h9pPQZyyVPPksRA==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.1.1",
@@ -1226,9 +1226,9 @@
       }
     },
     "just-extend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
-      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
       "dev": true
     },
     "locate-path": {
@@ -1270,12 +1270,12 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^2.4.2"
       }
     },
     "lolex": {
@@ -1296,9 +1296,9 @@
       }
     },
     "make-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+      "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
@@ -1337,9 +1337,9 @@
       }
     },
     "mocha": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.1.tgz",
-      "integrity": "sha512-9eWmWTdHLXh72rGrdZjNbG3aa1/3NRPpul1z0D979QpEnFdCG0Q5tv834N+94QEN2cysfV72YocQ3fn87s70fg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.0.tgz",
+      "integrity": "sha512-MymHK8UkU0K15Q/zX7uflZgVoRWiTjy0fXE/QjKts6mowUvGxOdPhZ2qj3b0iZdUrNZlW9LAIMFHB4IW+2b3EQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -1353,7 +1353,7 @@
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "3.13.1",
-        "log-symbols": "2.2.0",
+        "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "ms": "2.1.1",
@@ -1993,9 +1993,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-      "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -2260,9 +2260,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
     "tslint": {
@@ -2379,9 +2379,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
     "util-deprecate": {
@@ -2466,9 +2466,9 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
-      "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "compile": "tsc",
     "prepublishOnly": "npm run clean && npm install && npm run compile",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "test": "npm run compile && nyc mocha 'dist/test/**/*.js'; test -z \"$TEST_REDIS_URL\" && echo '!!! Warning: TEST_REDIS_URL unset, Redis tests did not run !!!'",
+    "test": "npm run compile && nyc mocha 'dist/test/**/*.js'; test -z \"$TEST_REDIS_URL\" && echo '!!! Warning: TEST_REDIS_URL unset, Redis tests did not run !!!' || true",
     "test:ci": "npm run compile && mkdir -p shippable/testresults shippable/codecoverage && nyc --reporter cobertura --report-dir shippable/codecoverage mocha --opts test/mocha.ci.opts 'dist/test/**/*.js'",
     "relock": "rm -rf node_modules package-lock.json; npm install --package-lock; npm out; true"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "compile": "tsc",
     "prepublishOnly": "npm run clean && npm install && npm run compile",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "test": "npm run compile && nyc mocha 'dist/test/**/*.js'",
+    "test": "npm run compile && nyc mocha 'dist/test/**/*.js'; test -z \"$TEST_REDIS_URL\" && echo '!!! Warning: TEST_REDIS_URL unset, Redis tests did not run !!!'",
     "test:ci": "npm run compile && mkdir -p shippable/testresults shippable/codecoverage && nyc --reporter cobertura --report-dir shippable/codecoverage mocha --opts test/mocha.ci.opts 'dist/test/**/*.js'",
     "relock": "rm -rf node_modules package-lock.json; npm install --package-lock; npm out; true"
   },

--- a/src/lib/RedisCache.ts
+++ b/src/lib/RedisCache.ts
@@ -33,7 +33,7 @@ export class RedisCache extends CacheInstance {
   private url: string;
   private redlock: Redlock;
 
-  constructor(redisUrl: string) {
+  constructor(redisUrl: string, readOnly: boolean = false ) {
     super();
 
     if (!redisUrl || (!redisUrl.startsWith('redis://') && !redisUrl.startsWith('rediss://'))) {
@@ -42,9 +42,10 @@ export class RedisCache extends CacheInstance {
 
     this.url = redisUrl;
     this.redisClient = new Redis(redisUrl, {
+      readOnly,
       retryStrategy: () => RedisCache.RETRY_DELAY,
       // master failover
-      reconnectOnError: (err: any) => err.message.startsWith('READONLY'),
+      reconnectOnError: (err: any) => !readOnly && err.message.startsWith('READONLY'),
       // This will prevent the get/setValue calls from hanging
       // if there is no active connection.
       enableOfflineQueue: false,

--- a/src/lib/RedisCache.ts
+++ b/src/lib/RedisCache.ts
@@ -33,7 +33,7 @@ export class RedisCache extends CacheInstance {
   private url: string;
   private redlock: Redlock;
 
-  constructor(redisUrl: string, readOnly: boolean = false ) {
+  constructor(redisUrl: string, readOnly: boolean = false) {
     super();
 
     if (!redisUrl || (!redisUrl.startsWith('redis://') && !redisUrl.startsWith('rediss://'))) {

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -93,7 +93,6 @@ export class WriteThroughCache extends CacheInstance {
   public async clear(): Promise<void> {
     await this.localCache.clear();
     await this.redisCacheForWriting.clear();
-    await this.redisCacheForReading.clear();
   }
 
   /**
@@ -102,7 +101,6 @@ export class WriteThroughCache extends CacheInstance {
   public async clearMemory(): Promise<void> {
     await this.localCache.clearMemory();
     await this.redisCacheForWriting.clearMemory();
-    await this.redisCacheForReading.clearMemory();
   }
 
   public isLockingSupported(): boolean {
@@ -110,12 +108,12 @@ export class WriteThroughCache extends CacheInstance {
   }
 
   public lock(resource: string, ttlMs: number): Promise<any> {
-    return this.redisCacheForReading.lock(resource, ttlMs) ;
+    return this.redisCacheForWriting.lock(resource, ttlMs);
   }
 
 
   public unlock(lock: any): Promise<void> {
-    return this.redisCacheForReading.unlock(lock);
+    return this.redisCacheForWriting.unlock(lock);
   }
 
 }

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -110,11 +110,12 @@ export class WriteThroughCache extends CacheInstance {
   }
 
   public lock(resource: string, ttlMs: number): Promise<any> {
-    return this.redisCacheForWriting.lock(resource, ttlMs) && this.redisCacheForReading.lock(resource, ttlMs) ;
+    return this.redisCacheForReading.lock(resource, ttlMs) ;
   }
 
+
   public unlock(lock: any): Promise<void> {
-    return this.redisCacheForWriting.unlock(lock) && this.redisCacheForReading.unlock(lock);
+    return this.redisCacheForReading.unlock(lock);
   }
 
 }

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -15,9 +15,7 @@ export class WriteThroughCache extends CacheInstance {
   constructor(redisUrl: string) {
     super();
     this.redisCacheForWriting = new RedisCache(redisUrl);
-    // Please note that redisCacheForReading will not guarantee a connection with an AWS replica
-    // We might hit the primary instance, but we should not get readonly errors on this connections.
-    this.redisCacheForReading = new RedisCache(redisUrl);
+    this.redisCacheForReading = new RedisCache(redisUrl, true);
     this.localCache = new LocalCache();
   }
 

--- a/test/WriteThroughCache_test.ts
+++ b/test/WriteThroughCache_test.ts
@@ -5,8 +5,9 @@ import { WriteThroughCache, LocalCache } from '../src/';
 
 function makeFakeWriteThroughCache(): WriteThroughCache {
   const cache = new WriteThroughCache('redis://localhost:9999');
-  cache['redisCache'] = new LocalCache();
-  cache['redisCache'].getTtl = async () => 1;
+  cache['redisCacheForWriting'] = new LocalCache();
+  cache['redisCacheForWriting'].getTtl = async () => 1;
+  cache['redisCacheForReading'] = cache['redisCacheForWriting'];
   return cache;
 }
 
@@ -39,7 +40,7 @@ describe('WriteThroughCache', () => {
       value = await cache['localCache'].getValue('key');
       expect(value).to.equal('value');
 
-      value = await cache['redisCache'].getValue('key');
+      value = await cache['redisCacheForReading'].getValue('key');
       expect(value).to.equal('value');
 
     });
@@ -59,7 +60,7 @@ describe('WriteThroughCache', () => {
       // await for Redis connection to be up
       await cache.isReady();
 
-      await cache['redisCache'].setValue('key', 'value', 100);
+      await cache['redisCacheForWriting'].setValue('key', 'value', 100);
 
       let value = await cache.getValue('key');
       expect(value).to.equal('value');
@@ -79,7 +80,7 @@ describe('WriteThroughCache', () => {
       let value = await cache.getValue('key');
       expect(value).to.equal('value');
 
-      value = await cache['redisCache'].getValue('key');
+      value = await cache['redisCacheForReading'].getValue('key');
       expect(value).not.to.exist;
 
     });
@@ -88,7 +89,7 @@ describe('WriteThroughCache', () => {
 
       const cache = makeFakeWriteThroughCache();
 
-      await cache['redisCache'].setValue('key', null);
+      await cache['redisCacheForWriting'].setValue('key', null);
 
       let value = await cache.getValue('key');
       expect(value).to.equal(null);
@@ -102,7 +103,7 @@ describe('WriteThroughCache', () => {
 
       const cache = makeFakeWriteThroughCache();
 
-      await cache['redisCache'].setValue('key', '');
+      await cache['redisCacheForWriting'].setValue('key', '');
 
       let value = await cache.getValue('key');
       expect(value).to.equal('');


### PR DESCRIPTION
# Issue Description

We noticed that most of our connections to a Redis cluster via cachette end up in the primary instance, instead of the replicas.

When reading or writing data to Redis we do use the same Redis connection, which is initialized in the `WriteThroughCache` constructor. 

If this connection is established to a replica and we try to do a write operation through the `WriteThroughCache` class then we will receive a READONLY Error.

if we receive a READONLY error we will keep trying to connect to the cluster until we have a connection with the primary instance (find more details here https://www.npmjs.com/package/ioredis#reconnect-on-error)

```js
    this.redisClient = new Redis(redisUrl, {
      retryStrategy: () => RedisCache.RETRY_DELAY,
      // master failover
      reconnectOnError: (err: any) => err.message.startsWith('READONLY'),
      // This will prevent the get/setValue calls from hanging
      // if there is no active connection.
      enableOfflineQueue: false,
    });
```

# Suggested Solution

Use two different Redis connections, one of them will be used only for write/update/delete operations and the 2nd connection will be used for the read operations only.
