### PR TITLE
use redisCacheForWriting for getTtl()

### DIFF
--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -75,7 +75,7 @@ export class WriteThroughCache extends CacheInstance {
    * @inheritdoc
    */
   public async getTtl(key: string): Promise<number | undefined> {
-    return this.redisCacheForReading.getTtl(key);
+    return this.redisCacheForWriting.getTtl(key);
   }
 
   /**


### PR DESCRIPTION
Fixes `Error while fetching ttl from the Redis cache Error: Stream isn't writeable and enableOfflineQueue options is false`