### PR TITLE
🔧 Fix npm install in npm 7

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 engine-strict=true
 strict-ssl=true
-ca=


### PR DESCRIPTION
This fixes failing to npm install anything with npm 7 (released last week)
in any project that has our `.npmrc`. It currently aborts with error
`UNABLE_TO_GET_ISSUER_CERT_LOCALLY`.

The problem stems from key `ca=`, which is set in all our projects `.npmrc`.
(Doc for `ca` lives at https://docs.npmjs.com/cli/v6/using-npm/config#ca )
It looks like npm 7 changed `.npmrc` parsing; let's run this a few times:

```bash
echo 'npm version:' && npm --version && echo && echo 'contents of .npmrc mentioning "ca":' && cat .npmrc | grep 'ca='; echo && echo 'output of npm config list' && npm config list -l | grep -E 'ca\s+='
```

With ye olden npm **6**, with `ca=` in `.npmrc`, we get (see the two last lines in particular):

```
npm version:
6.14.11

contents of .npmrc mentioning "ca":
ca=

output of npm config list
ca = ""  <------------------ HERE
; ca = null (overridden)
```

But now in npm **7**, with the same `ca=` config, see how we no longer get `""`,
we get `[""]`

```
npm version:
7.5.2

contents of .npmrc mentioning "ca":
ca=

output of npm config list
; ca = null ; overridden by project
ca = [""]  <------------------ HERE: BAAAAAAAAAAAAAAAAD
```

Then, obviously, all requests to npm fail, because this means we told npm
to accept only one TLS cert, the certificate equal to the empty string 😄.

So, why was this `ca=` in the first place? I dunno:

- Maybe it was set by someone attempting to follow the doc that says to
  *"Set to `null` to only allow 'known' registrars"* ?
- Maybe `ca=` used to be necessary in older times?

Anyway, the way to explicitly set `ca` null was never to `ca=`, it was to
`ca=null`, and doing this was useless anyway, since `ca=null` is the default
(and of course it is, it would have been super dubious for npm to accept
self-signed certs by default).
Proof, if I remove `ca=` from the `.npmrc` and re-run the script above,

In npm 6 (see how we good, `ca = null` by default):

```
npm version:
6.14.11

contents of .npmrc mentioning "ca":

output of npm config list
ca = null  <------------------ HERE: GOOD
```

And in npm 7 (we good too):

```
npm version:
7.5.2

contents of .npmrc mentioning "ca":

output of npm config list
ca = null  <------------------ HERE: GOOD TOO
```

With `ca=` removed, I was able to install both internal
and external packages using both npm 6 & 7, so all the above considered,
it looks like the right thing to do. Bye `ca=`.