### PR TITLE
💸 Don't run actions on draft pull requests

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -5,7 +5,7 @@ env:
 
 on:
   pull_request:
-    types: [opened, updated, synchronize]
+    types: [opened, updated, synchronize, ready_for_review, review_requested]
     branches:
       - master
     paths:
@@ -14,7 +14,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '[force-build]') && !contains(github.event.head_commit.message, '[skip ci]')}}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout 🛎️

--- a/.github/workflows/npm-lint.yml
+++ b/.github/workflows/npm-lint.yml
@@ -5,7 +5,7 @@ env:
 
 on:
   pull_request:
-    types: [opened, updated, synchronize]
+    types: [opened, updated, synchronize, ready_for_review, review_requested]
     branches:
       - master
     paths:
@@ -17,7 +17,7 @@ on:
 jobs:
   linter:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '[force-build]') && !contains(github.event.head_commit.message, '[skip ci]')}}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout 🛎️

--- a/.github/workflows/npm-tests.yml
+++ b/.github/workflows/npm-tests.yml
@@ -5,7 +5,7 @@ env:
   TEST_REDIS_URL: redis://localhost:6379
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, updated, synchronize, ready_for_review, review_requested]
     branches:
       - master
     paths:
@@ -16,7 +16,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '[force-build]') && !contains(github.event.head_commit.message, '[skip ci]')}}
+    if: ${{ github.event.pull_request.draft == false }}
 
     services:
       # Label used to access the service container


### PR DESCRIPTION
Goal:
The goal is to minimize our credit usage by not running tests on every single commit or on draft pull requests

Docs:

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
https://docs.github.com/en/rest/reference/pulls
Forum discussions:
https://github.community/t/dont-run-actions-on-draft-pull-requests/16817/10