### PR TITLE
💨 Support plain object as key for caching

### DIFF
--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -5,7 +5,7 @@ export abstract class CacheClient {
   protected cacheInstance: CacheInstance;
   protected buildCacheKey(propertyKey: string, args: any[]): string {
 
-    const buildKeyArgs = (args) => args
+    const buildKeyArgs = (args: any[]) => args
       .filter(x => x !== undefined && x !== null)
       .filter(x =>
         typeof x === 'string' ||

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -14,7 +14,7 @@ export abstract class CacheClient {
         (typeof x === 'object' && x.constructor.name === 'Object')
       ).map(x => {
         if (typeof x === 'object') {
-          return Object.values(x).join('-');
+          return Object.entries(x).map(([key, value]) => `${key}-${value}`).join('-');
         }
         return x.toString();
       });

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -6,8 +6,18 @@ export abstract class CacheClient {
   protected buildCacheKey(propertyKey: string, args: any[]): string {
     const keyParts = args
       .filter(x => x !== undefined && x !== null)
-      .filter(x => typeof x === 'string' || typeof x === 'number' || typeof x === 'boolean')
-      .map(x => x.toString());
+      .filter(x =>
+        typeof x === 'string' ||
+        typeof x === 'number' ||
+        typeof x === 'boolean' ||
+        // If the arg is an object, we check that it's not a instance of a class
+        (typeof x === 'object' && x.constructor.name !== 'Object')
+      ).map(x => {
+        if (typeof x === 'object') {
+          return Object.values(x).join('-');
+        }
+        return x.toString();
+      });
     return [
       propertyKey,
       ...keyParts,

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -14,6 +14,9 @@ export abstract class CacheClient {
         x === null
       ).map(x => {
         if (typeof x === 'object' && !Array.isArray(x) && x) {
+          // Check if we have a circular reference in the plain object
+          JSON.stringify(x);
+
           return Object.entries(x).sort().map(([key, value]) => {
             if (typeof value === 'object') {
               const nestedObjectKeys = buildKeyArgs([value])

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -38,8 +38,9 @@ export abstract class CacheClient {
       ...buildKeyArgs(args),
     ].join('-');
 
-    if (builtKey.length > 1000) {
-      throw new Error('Built key is bigger than 1000 chars');
+    const maxKeyLength = process.env.UNITO_CACHE_MAX_KEY_LENGTH || 1000;
+    if (builtKey.length > maxKeyLength) {
+      throw new Error(`Built key is bigger than ${maxKeyLength} chars`);
     }
 
     return builtKey;

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -11,7 +11,7 @@ export abstract class CacheClient {
         typeof x === 'number' ||
         typeof x === 'boolean' ||
         // If the arg is an object, we check that it's not a instance of a class
-        (typeof x === 'object' && x.constructor.name !== 'Object')
+        (typeof x === 'object' && x.constructor.name === 'Object')
       ).map(x => {
         if (typeof x === 'object') {
           return Object.values(x).join('-');

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -16,7 +16,7 @@ export abstract class CacheClient {
       ).map(x => {
         if (typeof x === 'object') {
           return Object.entries(x).map(([key, value]) => {
-            if (typeof value === 'object' && value) {
+            if (typeof value === 'object') {
               const nestedObjectKeys = buildKeyArgs([value])
               return `${key}-${nestedObjectKeys}`
             }

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -24,7 +24,8 @@ export abstract class CacheClient {
         }
 
         if (Array.isArray(x)) {
-          return x.sort().join('-');
+          const builtKey = buildKeyArgs(x.sort());
+          return builtKey.join('-');
         }
         return new String(x).valueOf();
       });

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -15,7 +15,7 @@ export abstract class CacheClient {
         (typeof x === 'object' && x.constructor.name === 'Object')
       ).map(x => {
         if (typeof x === 'object') {
-          return Object.entries(x).map(([key, value]) => {
+          return Object.entries(x).sort().map(([key, value]) => {
             if (typeof value === 'object') {
               const nestedObjectKeys = buildKeyArgs([value])
               return `${key}-${nestedObjectKeys}`

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -4,7 +4,8 @@ export abstract class CacheClient {
 
   protected cacheInstance: CacheInstance;
   protected buildCacheKey(propertyKey: string, args: any[]): string {
-    const keyParts = args
+
+    const buildKeyArgs = (args) => args
       .filter(x => x !== undefined && x !== null)
       .filter(x =>
         typeof x === 'string' ||
@@ -14,13 +15,20 @@ export abstract class CacheClient {
         (typeof x === 'object' && x.constructor.name === 'Object')
       ).map(x => {
         if (typeof x === 'object') {
-          return Object.entries(x).map(([key, value]) => `${key}-${value}`).join('-');
+          return Object.entries(x).map(([key, value]) => {
+            if (typeof value === 'object' && value) {
+              const nestedObjectKeys = buildKeyArgs([value])
+              return `${key}-${nestedObjectKeys}`
+            }
+            return `${key}-${value}`
+          }).join('-');
         }
         return x.toString();
       });
+
     return [
       propertyKey,
-      ...keyParts,
+      ...buildKeyArgs(args),
     ].join('-');
   }
 

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -217,23 +217,31 @@ describe('CacheClient', () => {
 
     it('will convert plain object values', async () => {
       const cacheClient = new MyCacheClient();
-      const expectedKey = 'functionName-argument-argument1-arg1-argument2-arg2-argument3-nestedArg1-nestedArg1-nestedArg2-nestedArg2';
+      const expectedKey = 'functionName-argument-property1-prop1-property2-prop2-property3-nestedProp1-nestedProp1-nestedProp2-nestedProp2';
 
       const keyWithSortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
-        { argument1: 'arg1', argument2: 'arg2', argument3: { nestedArg1: 'nestedArg1', nestedArg2: 'nestedArg2' } },
+        { property1: 'prop1', property2: 'prop2', property3: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
         new Date(),
       ]);
       expect(keyWithSortedObjectProperties).to.equal(expectedKey);
+    })
+
+    it('will convert plain object values and the result should be the same key if two objects have the same properties but not in the same order', async () => {
+      const cacheClient = new MyCacheClient();
+
+      const keyWithSortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
+        'argument',
+        { property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' }, property2: 'prop2' },
+      ]);
 
       const keyWithUnsortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
-        { argument2: 'arg2', argument1: 'arg1', argument3: { nestedArg2: 'nestedArg2', nestedArg1: 'nestedArg1' } },
+        {  property2: 'prop2' , property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
         new Date(),
       ]);
-      expect(keyWithUnsortedObjectProperties).to.equal(expectedKey);
+      expect(keyWithUnsortedObjectProperties).to.equal(keyWithSortedObjectProperties);
     })
-
   });
 
 });

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -303,5 +303,4 @@ describe('CacheClient', () => {
       expect(() => cacheClient['buildCacheKey']('functionName', [obj2])).to.throw();
     })
   });
-
 });

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -217,8 +217,18 @@ describe('CacheClient', () => {
 
     it('will convert plain object values', async () => {
       const cacheClient = new MyCacheClient();
-      const key = cacheClient['buildCacheKey']('functionName', ['argument', { argument1: 'arg1', argument2: 'arg2', argument3: { nestedArg1: 'nestedArg1' } }, new Date()]);
-      expect(key).to.equal('functionName-argument-argument1-arg1-argument2-arg2-argument3-nestedArg1-nestedArg1');
+      const keyWithSortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
+        'argument',
+        { argument1: 'arg1', argument2: 'arg2', argument3: { nestedArg1: 'nestedArg1', nestedArg2: 'nestedArg2' } },
+        new Date(),
+      ]);
+      expect(keyWithSortedObjectProperties).to.equal('functionName-argument-argument1-arg1-argument2-arg2-argument3-nestedArg1-nestedArg1-nestedArg2-nestedArg2');
+      const keyWithUnsortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
+        'argument',
+        { argument2: 'arg2', argument1: 'arg1', argument3: { nestedArg2: 'nestedArg2', nestedArg1: 'nestedArg1' } },
+        new Date(),
+      ]);
+      expect(keyWithUnsortedObjectProperties).to.equal('functionName-argument-argument1-arg1-argument2-arg2-argument3-nestedArg1-nestedArg1-nestedArg2-nestedArg2');
     })
 
   });

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -217,8 +217,8 @@ describe('CacheClient', () => {
 
     it('will convert plain object values', async () => {
       const cacheClient = new MyCacheClient();
-      const key = cacheClient['buildCacheKey']('functionName', ['argument', { argument1: 'arg1', argument2: 'arg2' }, new Date()]);
-      expect(key).to.equal('functionName-argument-argument1-arg1-argument2-arg2');
+      const key = cacheClient['buildCacheKey']('functionName', ['argument', { argument1: 'arg1', argument2: 'arg2', argument3: { nestedArg1: 'nestedArg1' } }, new Date()]);
+      expect(key).to.equal('functionName-argument-argument1-arg1-argument2-arg2-argument3-nestedArg1-nestedArg1');
     })
 
   });

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -217,18 +217,21 @@ describe('CacheClient', () => {
 
     it('will convert plain object values', async () => {
       const cacheClient = new MyCacheClient();
+      const expectedKey = 'functionName-argument-argument1-arg1-argument2-arg2-argument3-nestedArg1-nestedArg1-nestedArg2-nestedArg2';
+
       const keyWithSortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
         { argument1: 'arg1', argument2: 'arg2', argument3: { nestedArg1: 'nestedArg1', nestedArg2: 'nestedArg2' } },
         new Date(),
       ]);
-      expect(keyWithSortedObjectProperties).to.equal('functionName-argument-argument1-arg1-argument2-arg2-argument3-nestedArg1-nestedArg1-nestedArg2-nestedArg2');
+      expect(keyWithSortedObjectProperties).to.equal(expectedKey);
+
       const keyWithUnsortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
         { argument2: 'arg2', argument1: 'arg1', argument3: { nestedArg2: 'nestedArg2', nestedArg1: 'nestedArg1' } },
         new Date(),
       ]);
-      expect(keyWithUnsortedObjectProperties).to.equal('functionName-argument-argument1-arg1-argument2-arg2-argument3-nestedArg1-nestedArg1-nestedArg2-nestedArg2');
+      expect(keyWithUnsortedObjectProperties).to.equal(expectedKey);
     })
 
   });

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -217,15 +217,49 @@ describe('CacheClient', () => {
 
     it('will convert plain object values', async () => {
       const cacheClient = new MyCacheClient();
-      const expectedKey = 'functionName-argument-property1-prop1-property2-prop2-property3-nestedProp1-nestedProp1-nestedProp2-nestedProp2-value1-value2';
+      const expectedKey = 'functionName-argument-property1-prop1-property2-prop2-property3-nestedProp1-nestedProp1-nestedProp2-nestedProp2';
 
       const keyWithSortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
         { property1: 'prop1', property2: 'prop2', property3: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
         new Date(),
-        ['value1', 'value2']
       ]);
       expect(keyWithSortedObjectProperties).to.equal(expectedKey);
+    })
+
+    it('will convert array values', async () => {
+      const cacheClient = new MyCacheClient();
+      const expectedKey = 'functionName-prop1-propValue1-prop2-propValue2-value1-value2';
+
+      const keyWithArrayValues = cacheClient['buildCacheKey']('functionName', [
+       [
+         { prop1: 'propValue1', prop2: 'propValue2' },
+         'value1',
+         'value2',
+       ],
+      ]);
+      expect(keyWithArrayValues).to.equal(expectedKey);
+    })
+
+    it('will convert array values and the result should be the same key if two array own the same properties but not in the same order', async () => {
+      const cacheClient = new MyCacheClient();
+
+      const keyWithSortedArrayValues= cacheClient['buildCacheKey']('functionName', [
+        [
+          { prop1: 'propValue1', prop2: 'propValue2' },
+          'value1',
+          'value2',
+        ],
+      ]);
+
+      const keyWithUnsortedArrayValues= cacheClient['buildCacheKey']('functionName', [
+        [
+          'value1',
+          'value2',
+          { prop1: 'propValue1', prop2: 'propValue2' },
+        ],
+      ]);
+      expect(keyWithSortedArrayValues).to.equal(keyWithUnsortedArrayValues);
     })
 
     it('will convert plain object values and the result should be the same key if two objects have the same properties but not in the same order', async () => {

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -191,11 +191,11 @@ describe('CacheClient', () => {
       cacheInstance = new LocalCache();
     }
 
-    it('will ignore null or undefined', async () => {
+    it('will add null or undefined to the key', async () => {
 
       const cacheClient = new MyCacheClient();
       const key = cacheClient['buildCacheKey']('functionName', [null, undefined, 'argument']);
-      expect(key).to.equal('functionName-argument');
+      expect(key).to.equal('functionName-null-undefined-argument');
 
     });
 
@@ -217,12 +217,13 @@ describe('CacheClient', () => {
 
     it('will convert plain object values', async () => {
       const cacheClient = new MyCacheClient();
-      const expectedKey = 'functionName-argument-property1-prop1-property2-prop2-property3-nestedProp1-nestedProp1-nestedProp2-nestedProp2';
+      const expectedKey = 'functionName-argument-property1-prop1-property2-prop2-property3-nestedProp1-nestedProp1-nestedProp2-nestedProp2-value1-value2';
 
       const keyWithSortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
         { property1: 'prop1', property2: 'prop2', property3: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
         new Date(),
+        ['value1', 'value2']
       ]);
       expect(keyWithSortedObjectProperties).to.equal(expectedKey);
     })
@@ -240,6 +241,17 @@ describe('CacheClient', () => {
         { property2: 'prop2', property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
       ]);
       expect(keyWithUnsortedObjectProperties).to.equal(keyWithSortedObjectProperties);
+    })
+
+    it('should throw if key is bigger than 1000', async () => {
+      const cacheClient = new MyCacheClient();
+
+      const bigArray: string[] = [];
+      while (bigArray.length < 1000) {
+        bigArray.push('myValue');
+      }
+
+      expect(() => cacheClient['buildCacheKey']('functionName', [bigArray])).to.throw();
     })
   });
 

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -237,7 +237,7 @@ describe('CacheClient', () => {
 
       const keyWithUnsortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
-        { property2: 'prop2' , property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
+        { property2: 'prop2', property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
         new Date(),
       ]);
       expect(keyWithUnsortedObjectProperties).to.equal(keyWithSortedObjectProperties);

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -234,11 +234,13 @@ describe('CacheClient', () => {
       const keyWithSortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
         { property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' }, property2: 'prop2' },
+        ['value1', 'value2'],
       ]);
 
       const keyWithUnsortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
         { property2: 'prop2', property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
+        ['value2', 'value1'],
       ]);
       expect(keyWithUnsortedObjectProperties).to.equal(keyWithSortedObjectProperties);
     })

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -237,7 +237,7 @@ describe('CacheClient', () => {
 
       const keyWithUnsortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
-        {  property2: 'prop2' , property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
+        { property2: 'prop2' , property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
         new Date(),
       ]);
       expect(keyWithUnsortedObjectProperties).to.equal(keyWithSortedObjectProperties);

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -215,6 +215,12 @@ describe('CacheClient', () => {
 
     });
 
+    it('will convert plain object values', async () => {
+      const cacheClient = new MyCacheClient();
+      const key = cacheClient['buildCacheKey']('functionName', ['argument', { argument1: 'arg1', argument2: 'arg2' }, new Date()]);
+      expect(key).to.equal('functionName-argument-arg1-arg2');
+    })
+
   });
 
 });

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -289,6 +289,19 @@ describe('CacheClient', () => {
 
       expect(() => cacheClient['buildCacheKey']('functionName', [bigArray])).to.throw();
     })
+
+    it('should detect circular reference in an object', async () => {
+      const cacheClient = new MyCacheClient();
+      const obj2: any = {};
+      const obj: any = {
+        property1: 'hello',
+        property2: obj2,
+      };
+
+      obj2.property1 = obj;
+
+      expect(() => cacheClient['buildCacheKey']('functionName', [obj2])).to.throw();
+    })
   });
 
 });

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -218,7 +218,7 @@ describe('CacheClient', () => {
     it('will convert plain object values', async () => {
       const cacheClient = new MyCacheClient();
       const key = cacheClient['buildCacheKey']('functionName', ['argument', { argument1: 'arg1', argument2: 'arg2' }, new Date()]);
-      expect(key).to.equal('functionName-argument-arg1-arg2');
+      expect(key).to.equal('functionName-argument-argument1-arg1-argument2-arg2');
     })
 
   });

--- a/test/CacheClient_test.ts
+++ b/test/CacheClient_test.ts
@@ -238,7 +238,6 @@ describe('CacheClient', () => {
       const keyWithUnsortedObjectProperties = cacheClient['buildCacheKey']('functionName', [
         'argument',
         { property2: 'prop2', property1: { nestedProp1: 'nestedProp1', nestedProp2: 'nestedProp2' } },
-        new Date(),
       ]);
       expect(keyWithUnsortedObjectProperties).to.equal(keyWithSortedObjectProperties);
     })


### PR DESCRIPTION
When we have a plain object as an argument in a function call that is cached, we are not able to create different keys as cacheKey even if the object is not the same in 2 different calls. This behavior results in fetching the wrong result for a call that has been cached before. 

This PR introduces the support of plain object in `buildCacheKey` function.

We basically get all the values of the plain object and join them with `-` char. In the case of: 

```
getFoo(
	arg1 = 'coucou',
	arg2 = { nestedProp: 'nestedValue', nestedProp2: 'nestedValue2' },
)
```
Will lead to this cacheKey: `getFoo-coucou-nestedProp-nestedValue-nestedProp2-nestedValue2`.

This PR include the support for `undefined`, `null` and array as well!