### PR TITLE
🔧 Say! No! To! Useless noisy wasteful GHA runs!

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -5,7 +5,9 @@ env:
 
 on:
   pull_request:
-    types: [opened, updated, synchronize, ready_for_review, review_requested]
+    # adding 'ready_for_review' to the default [opened, synchronize, reopened] since we don't run on pr.draft == false
+    # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/npm-lint.yml
+++ b/.github/workflows/npm-lint.yml
@@ -5,7 +5,9 @@ env:
 
 on:
   pull_request:
-    types: [opened, updated, synchronize, ready_for_review, review_requested]
+    # adding 'ready_for_review' to the default [opened, synchronize, reopened] since we don't run on pr.draft == false
+    # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/npm-tests.yml
+++ b/.github/workflows/npm-tests.yml
@@ -5,7 +5,9 @@ env:
   TEST_REDIS_URL: redis://localhost:6379
 on:
   pull_request:
-    types: [opened, updated, synchronize, ready_for_review, review_requested]
+    # adding 'ready_for_review' to the default [opened, synchronize, reopened] since we don't run on pr.draft == false
+    # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:


### PR DESCRIPTION
This PR is part of a propagation to all Unito projects of the GHA trigger
config pimping we validated. This series of PRs generalizes 4 things:

1. It disables running CI jobs on `review_requested`, which makes no sense,
   is noise, and uselessly costs GHA credits.
2. It removes leftovers of running CI jobs on `edited` (which happens on
   touching PR title / description), also causing noise and GHA credits.
3. It removes all `updated` triggers, which were a noop because a typo here since
   day 1 of GHA@unito! This event doesn't exist! It's probably a typo for `edited`,
   which we don't want (point 2. above).
   https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
4. It preserves running cosmetic `pr-name` jobs on `[opened, edited]`,
   which is exactly what we want.

With that, GHA should run when we expect it to:

1. CI jobs (npm test, lint, audit, etc) will:
  1. Run initially (`opened`)
  2. Run on every new commit or rebase (`synchronize`)
  3. Run when moving from Draft to Ready (`ready_for_review`)
2. (Untouched as already correct) PR title format check runs on `[opened, edited]`

, and with that, CI jobs are almost back to GHA defaults (`[opened, synchronize, reopened]`) !
Except the extra `review_requested` is required because we only run `if: ${{ draft == false }}`