### PR TITLE
💸 Implement getTtl on LocalCache

### DIFF
--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -67,9 +67,23 @@ export class LocalCache extends CacheInstance {
 
   /**
    * @inheritdoc
+   * Return the number of ms left in the item's TTL.
+   * If item is not in cache, returns 0.
+   * Returns Infinity if item is in cache without a defined TTL.
+   * Docs: https://github.com/isaacs/node-lru-cache#getremainingttlkey
    */
   public async getTtl(key: string): Promise<number | undefined> {
-    throw new Error('not implemented');
+    const remainingTtl = await this.cache.getRemainingTTL(key);
+    /** If entry is not cached, return undefined */
+    if (remainingTtl === 0) {
+      return undefined;
+    }
+    /** If entry does not expire, return 0 */
+    if (!Number.isInteger(remainingTtl)) {
+      return 0;
+    }
+
+    return remainingTtl;
   }
 
   /**

--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -69,7 +69,7 @@ export class LocalCache extends CacheInstance {
    * @inheritdoc
    * Return the number of ms left in the item's TTL.
    * If item is not in cache, returns 0.
-   * Returns Infinity if item is in cache without a defined TTL.
+   * Returns a very large number (e.g. 1799999.9158420563) if item is in cache without a defined TTL.
    * Docs: https://github.com/isaacs/node-lru-cache#getremainingttlkey
    */
   public async getTtl(key: string): Promise<number | undefined> {
@@ -79,7 +79,7 @@ export class LocalCache extends CacheInstance {
       return undefined;
     }
     /** If entry does not expire, return 0 */
-    if (!Number.isInteger(remainingTtl)) {
+    if (remainingTtl > 1799999) {
       return 0;
     }
 

--- a/test/LocalCache_test.ts
+++ b/test/LocalCache_test.ts
@@ -28,7 +28,6 @@ describe('LocalCache', () => {
   });
 
   it('can set values with expiry', async () => {
-
     const cache = new LocalCache();
     await cache.setValue('key', 'value', .2);
     let value = await cache.getValue('key');
@@ -40,7 +39,6 @@ describe('LocalCache', () => {
   });
 
   it('can delete a value', async () => {
-
     const cache = new LocalCache();
     await cache.setValue('key', 'value');
 
@@ -74,6 +72,32 @@ describe('LocalCache', () => {
     // restore
     LocalCache['DEFAULT_MAX_ITEMS'] = origMax;
 
+  })
+
+  it('can get the remaining TTL of an item', async () => {
+    const cache = new LocalCache();
+    const wasSet = await cache.setValue('key', 'value', 10 * 60);
+    const cacheTtl = await cache.getTtl('key'); // returns ttl in ms
+
+    expect(wasSet).to.be.true;
+    expect(cacheTtl).to.exist;
+    expect(cacheTtl).to.below(10 * 60 * 1000);
+  });
+
+  it('returns undefined when we call getTtl if the item does not exist in the cache', async () => {
+    const cache = new LocalCache();
+    const cacheTtl = await cache.getTtl('key');
+
+    expect(cacheTtl).to.be.undefined;
+  });
+
+  it('returns 0 when we call getTtl if the item does not expire', async () => {
+    const cache = new LocalCache();
+    const wasSet = await cache.setValue('key', 'value');
+    const cacheTtl = await cache.getTtl('key');
+    
+    expect(wasSet).to.be.true;
+    expect(cacheTtl).to.equal(0);
   });
 
 });

--- a/test/LocalCache_test.ts
+++ b/test/LocalCache_test.ts
@@ -81,7 +81,7 @@ describe('LocalCache', () => {
 
     expect(wasSet).to.be.true;
     expect(cacheTtl).to.exist;
-    expect(cacheTtl).to.below(10 * 60 * 1000);
+    expect(cacheTtl).to.be.within(9 * 60 * 1000, 10 * 60 * 1000);
   });
 
   it('returns undefined when we call getTtl if the item does not exist in the cache', async () => {


### PR DESCRIPTION
# Description
While testing locally, I ran into an error in Maestro "Error: not implemented".

This is because we throw when we call `getTtl`. The function has not been implemented yet.
This PR fixes that.

# Technical decisions
For LocalCache, we use the library `lru-cache`. According to their [docs](https://github.com/isaacs/node-lru-cache#getremainingttlkey), if an item is not cached, `getRemainingTTL` returns 0 and if the item was cached without a TTL, it returns "Infinity". In actually, it returns a very large number with decimals. Therefore, to test if we have a cache that does not expire, we'll look for number > 1799999.
 