### PR TITLE
💨 Restore locks to WriteThroughCache

### DIFF
--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -105,12 +105,29 @@ export class WriteThroughCache extends CacheInstance {
 
   /**
    * @inheritdoc
-   * Locking is *not* supported by the Write-Through cache. You want either:
-   * - The full-fledged RedisCache for prod workloads
-   * - A dumb LocalCache for dev/local workloads
    */
-  public isLockingSupported(): boolean {
-    return false;
+   public async hasLock(prefix: string): Promise<boolean> {
+    return this.redisCacheForWriting.hasLock(prefix);
   }
 
+  /**
+   * @inheritdoc
+   */
+  public isLockingSupported(): boolean {
+    return true;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public lock(resource: string, ttlMs: number): Promise<any> {
+    return this.redisCacheForWriting.lock(resource, ttlMs);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public unlock(lock: any): Promise<void> {
+    return this.redisCacheForWriting.unlock(lock);
+  }
 }


### PR DESCRIPTION
# 💨 Restore locks to WriteThroughCache

On https://github.com/unitoio/cachette/pull/58/files#diff-a83bbe9da3aba81217e1177f1d86aa274983f10edaccd2ffb89922e73b1f22d5R106-R113 the lock capabilities were taken away from `WriteThroughCache`. The comments in the PR mention `WriteThroughCache` not being used for prod, and thus it not needing lock features.
However there are plenty of projects in production using WriteThroughCaches that'd still be interested in using a `lock`. 

No tests were added here because the entire locking feature is automatically being tested by `test/CacheInstance_test.ts` for `WriteThroughCache` too.
 