### PR TITLE
🔧 README: Remove badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # cachette
-[![Dependency Status](https://david-dm.org/unitoio/cachette.svg)](https://david-dm.org/unitoio/cachette)
-[![npm version](https://badge.fury.io/js/cachette.svg)](https://badge.fury.io/js/cachette)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Resilient cache library supporting concurrent requests through local cache or Redis.
 


### PR DESCRIPTION
One was broken, and the others also rely on third-parties that might break too.
They're non essential, and don't add much as already well exposed by GitHub.
Let's remove them.