### PR TITLE
🐛 postprepare instead of postinstall to avoid running when a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "npm run compile && nyc mocha --config test/mocharc.js 'dist/test/**/*.js'; test -z \"$TEST_REDIS_URL\" && echo '!!! Warning: TEST_REDIS_URL unset, Redis tests did not run !!!' || true",
     "test:ci": "npm run compile && mkdir -p ci_output/testresults && mocha --config test/mocharc-ci.js 'dist/test/**/*.js'",
     "relock": "rm -rf node_modules package-lock.json; npm install --package-lock; npm out; true",
-    "postinstall": "npm run --silent githook-install",
+    "postprepare": "npm run --silent githook-install",
     "githook-install": "echo '#!/usr/bin/env sh\necho \"⚠️ Reminder that cachette is a *public* repo! ⚠️\"\necho \"No private info in: branch name, commit message, PR title & description & comments!\"\necho \"Ctrl+C to abort git push, Enter to proceed.\"\nread REPLY < /dev/tty' > '.git/hooks/pre-push' && chmod +x '.git/hooks/pre-push'"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:ci": "npm run compile && mkdir -p ci_output/testresults && mocha --config test/mocharc-ci.js 'dist/test/**/*.js'",
     "relock": "rm -rf node_modules package-lock.json; npm install --package-lock; npm out; true",
     "postprepare": "npm run --silent githook-install",
-    "githook-install": "echo '#!/usr/bin/env sh\necho \"⚠️ Reminder that cachette is a *public* repo! ⚠️\"\necho \"No private info in: branch name, commit message, PR title & description & comments!\"\necho \"Ctrl+C to abort git push, Enter to proceed.\"\nread REPLY < /dev/tty' > '.git/hooks/pre-push' && chmod +x '.git/hooks/pre-push'"
+    "githook-install": "mkdir -p .git/hooks/ && echo '#!/usr/bin/env sh\necho \"⚠️ Reminder that cachette is a *public* repo! ⚠️\"\necho \"No private info in: branch name, commit message, PR title & description & comments!\"\necho \"Ctrl+C to abort git push, Enter to proceed.\"\nread REPLY < /dev/tty' > '.git/hooks/pre-push' && chmod +x '.git/hooks/pre-push'"
   },
   "nyc": {
     "cache": false,


### PR DESCRIPTION
Using a postprepare instead of postinstall avoids running the script when installing cachette as a dependency in other projects and runs the script at least as often.

I'm not a fan of git hooks and would love if we didn't need to have this, but I get what you are trying to do, so here's a fix in case we decide we really need this :)

![image](https://github.com/unitoio/cachette/assets/139371381/911b7ee9-a8bc-474a-9670-2c8e6d50dc29)


