### PR TITLE
💨 Expose wait command

### DIFF
--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -124,7 +124,7 @@ export abstract class CacheClient {
    * Wait for the write commands to be acknowledged by the replicas.
    * This is useful when you want to ensure data is freshness on all nodes of the cluster.
    */
-  public async waitForReplication(replicas, timeout): Promise<number> {
+  public async waitForReplication(replicas: number = 5, timeout: number = 200): Promise<number> {
     return this.cacheInstance.waitForReplication(replicas, timeout);
   }
 

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -123,6 +123,8 @@ export abstract class CacheClient {
   /**
    * Wait for the write commands to be acknowledged by the replicas.
    * This is useful when you want to ensure data is freshness on all nodes of the cluster.
+   * We're defaulting to 5 replicas because it is the maximum number of read-only replica nodes
+   * that you can have for each shard in AWS-Elastic cache (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.Redis.Groups.html)
    */
   public async waitForReplication(replicas: number = 5, timeout: number = 200): Promise<number> {
     return this.cacheInstance.waitForReplication(replicas, timeout);

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -125,6 +125,9 @@ export abstract class CacheClient {
    * This is useful when you want to ensure data is freshness on all nodes of the cluster.
    * We're defaulting to 5 replicas because it is the maximum number of read-only replica nodes
    * that you can have for each shard in AWS-Elastic cache (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.Redis.Groups.html)
+   * 
+   * /!\ If the number of replicas asked for acknowledgment is greater than the number of replicas in the cluster, the function will always block
+   * /!\ until the timeout is reached. Make sure you know the number of replicas in your cluster when calling this function.
    */
   public async waitForReplication(replicas: number = 5, timeout: number = 50): Promise<number> {
     return this.cacheInstance.waitForReplication(replicas, timeout);

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -121,6 +121,14 @@ export abstract class CacheClient {
   }
 
   /**
+   * Wait for the write commands to be acknowledged by the replicas.
+   * This is useful when you want to ensure data is freshness on all nodes of the cluster.
+   */
+  public async waitForReplication(replicas, timeout): Promise<number> {
+    return this.cacheInstance.waitForReplication(replicas, timeout);
+  }
+
+  /**
    * Gets the valued returned from a cached function call,
    * using the CacheClient.cached.
    */

--- a/src/lib/CacheClient.ts
+++ b/src/lib/CacheClient.ts
@@ -126,7 +126,7 @@ export abstract class CacheClient {
    * We're defaulting to 5 replicas because it is the maximum number of read-only replica nodes
    * that you can have for each shard in AWS-Elastic cache (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.Redis.Groups.html)
    */
-  public async waitForReplication(replicas: number = 5, timeout: number = 200): Promise<number> {
+  public async waitForReplication(replicas: number = 5, timeout: number = 50): Promise<number> {
     return this.cacheInstance.waitForReplication(replicas, timeout);
   }
 

--- a/src/lib/CacheInstance.ts
+++ b/src/lib/CacheInstance.ts
@@ -59,7 +59,8 @@ export abstract class CacheInstance extends EventEmitter {
   public abstract delValue(key: string): Promise<void>;
 
   /**
-   * This command blocks the current client until all the previous write commands are successfully transferred and acknowledged by at least the specified number of replicas.
+   * This command blocks the current client until all the previous write commands are
+   * successfully transferred and acknowledged by at least the specified number of replicas.
    * 
    * @param replicas The number of replicas that should acknowledge write operations.
    * @param timeout The maximum amount of time to wait in milliseconds.

--- a/src/lib/CacheInstance.ts
+++ b/src/lib/CacheInstance.ts
@@ -58,6 +58,15 @@ export abstract class CacheInstance extends EventEmitter {
    */
   public abstract delValue(key: string): Promise<void>;
 
+  /**
+   * This command blocks the current client until all the previous write commands are successfully transferred and acknowledged by at least the specified number of replicas.
+   * 
+   * @param replicas The number of replicas that should acknowledge write operations.
+   * @param timeout The maximum amount of time to wait in milliseconds.
+   * 
+   */
+  public abstract waitForReplication(replicas: number, timeout: number): Promise<number>;
+
 
   /**
    * clear the whole cache

--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -95,6 +95,13 @@ export class LocalCache extends CacheInstance {
   /**
    * @inheritdoc
    */
+  public async waitForReplication(replicas: number, timeout: number): Promise<number> {
+    return 0;
+  }
+
+  /**
+   * @inheritdoc
+   */
   public async clear(): Promise<void> {
     this.cache.clear();
   }

--- a/src/lib/RedisCache.ts
+++ b/src/lib/RedisCache.ts
@@ -328,6 +328,14 @@ export class RedisCache extends CacheInstance {
   /**
    * @inheritdoc
    */
+  public async waitForReplication(replicas: number, timeout: number): Promise<number> {
+    this.emit('wait');
+    return this.redisClient.wait(replicas, timeout);
+  }
+
+  /**
+   * @inheritdoc
+   */
   public async clear(): Promise<void> {
     await this.redisClient.flushall();
   }

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -90,6 +90,15 @@ export class WriteThroughCache extends CacheInstance {
   /**
    * @inheritdoc
    */
+  public async waitForReplication(replicas: number, timeout: number): Promise<number> {
+    this.emit('wait')
+    await this.localCache.waitForReplication(replicas, timeout);
+    return this.redisCacheForWriting.waitForReplication(replicas, timeout);
+  }
+
+  /**
+   * @inheritdoc
+   */
   public async clear(): Promise<void> {
     await this.localCache.clear();
     await this.redisCacheForWriting.clear();

--- a/test/RedisCache_test.ts
+++ b/test/RedisCache_test.ts
@@ -217,4 +217,28 @@ describe('RedisCache', () => {
       expect(await cache.itemCount()).to.equal(0);
     });
   });
+
+  describe('waitForReplication', () => {
+      it('wait for replication', async function (): Promise<void> {
+        if (!process.env.TEST_REDIS_URL) {
+          this.skip();
+        }
+
+        const cache = new RedisCache(process.env.TEST_REDIS_URL as string);
+        await cache.isReady();
+
+        // Just to be sure that the cache is really empty...
+        await cache.clear();
+
+        await cache.setValue('test1', 'value1');
+        await cache.setValue('test2', 'value2');
+        await cache.setValue('test3', 'value3');
+        await cache.delValue('test1');
+        
+        const replicationAcknowledged = await cache.waitForReplication(0, 100);
+
+        // No replicas so we expect 0. This test basically confirms that waitForRepication doesn't crash. 🤷‍♂️
+        expect(replicationAcknowledged).to.equal(0);
+      })
+  });
 });

--- a/test/RedisCache_test.ts
+++ b/test/RedisCache_test.ts
@@ -227,13 +227,9 @@ describe('RedisCache', () => {
         const cache = new RedisCache(process.env.TEST_REDIS_URL as string);
         await cache.isReady();
 
-        // Just to be sure that the cache is really empty...
         await cache.clear();
 
         await cache.setValue('test1', 'value1');
-        await cache.setValue('test2', 'value2');
-        await cache.setValue('test3', 'value3');
-        await cache.delValue('test1');
         
         const replicationAcknowledged = await cache.waitForReplication(0, 100);
 

--- a/test/RedisCache_test.ts
+++ b/test/RedisCache_test.ts
@@ -233,7 +233,7 @@ describe('RedisCache', () => {
         
         const replicationAcknowledged = await cache.waitForReplication(0, 100);
 
-        // No replicas so we expect 0. This test basically confirms that waitForRepication doesn't crash. 🤷‍♂️
+        // No replicas so we expect 0. This test basically confirms that waitForReplication doesn't crash. 🤷‍♂️
         expect(replicationAcknowledged).to.equal(0);
       })
   });

--- a/test/RedisCache_test.ts
+++ b/test/RedisCache_test.ts
@@ -231,7 +231,7 @@ describe('RedisCache', () => {
 
       await cache.setValue('test1', 'value1');
       
-      const replicationAcknowledged = await cache.waitForReplication(0, 100);
+      const replicationAcknowledged = await cache.waitForReplication(0, 50);
 
       // No replicas so we expect 0. This test basically confirms that waitForReplication doesn't crash. 🤷‍♂️
       expect(replicationAcknowledged).to.equal(0);

--- a/test/RedisCache_test.ts
+++ b/test/RedisCache_test.ts
@@ -219,22 +219,22 @@ describe('RedisCache', () => {
   });
 
   describe('waitForReplication', () => {
-      it('wait for replication', async function (): Promise<void> {
-        if (!process.env.TEST_REDIS_URL) {
-          this.skip();
-        }
+    it('wait for replication', async function (): Promise<void> {
+      if (!process.env.TEST_REDIS_URL) {
+        this.skip();
+      }
 
-        const cache = new RedisCache(process.env.TEST_REDIS_URL as string);
-        await cache.isReady();
+      const cache = new RedisCache(process.env.TEST_REDIS_URL as string);
+      await cache.isReady();
 
-        await cache.clear();
+      await cache.clear();
 
-        await cache.setValue('test1', 'value1');
-        
-        const replicationAcknowledged = await cache.waitForReplication(0, 100);
+      await cache.setValue('test1', 'value1');
+      
+      const replicationAcknowledged = await cache.waitForReplication(0, 100);
 
-        // No replicas so we expect 0. This test basically confirms that waitForReplication doesn't crash. 🤷‍♂️
-        expect(replicationAcknowledged).to.equal(0);
-      })
+      // No replicas so we expect 0. This test basically confirms that waitForReplication doesn't crash. 🤷‍♂️
+      expect(replicationAcknowledged).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
Exposing Redis' WAIT command which can be useful to ensure data freshness across all nodes of a cluster.

Adding arbitrary default replica of 5 (the maximum supported by AWS Elasticache) and timeout to 200 millisecond. These could be parametrized from the client. Recommending to keep the timeout as low as possible since this is a blocking operation. The client can know whether or not the expected number of replicas acknowledged the last command by comparing the return value of `waitForReplication`. It will return the number of replicas that acknowledge