### PR TITLE
💨 Expose Get keys from RedisCache

### DIFF
--- a/src/lib/CacheInstance.ts
+++ b/src/lib/CacheInstance.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from 'node:events';
 export type CachableValue = any;
 export type FetchingFunction = () => Promise<CachableValue>;
 
-
 export abstract class CacheInstance extends EventEmitter {
 
   /**
@@ -26,6 +25,17 @@ export abstract class CacheInstance extends EventEmitter {
    *
    */
   public abstract getValue(key: string): Promise<CachableValue>;
+
+  /**
+   * Find all keys matching the given pattern
+   *
+   * @param pattern   The pattern to match (glob-style, e.g. 'prefix:*')
+   *
+   * @return      The keys matching the pattern, or an empty array if
+   *              no such keys exist.
+   *
+   */
+  public abstract getKeys(pattern: string): Promise<string[]>;
 
   /**
    * Get the TTL of an entry, in ms

--- a/src/lib/LocalCache.ts
+++ b/src/lib/LocalCache.ts
@@ -77,7 +77,7 @@ export class LocalCache extends CacheInstance {
 
     const regex = this.patternToRegex(pattern);
 
-    for (let value of keysGenerator) {
+    for (const value of keysGenerator) {
       if (regex.test(value)) {
         keys.push(value);
       }

--- a/src/lib/RedisCache.ts
+++ b/src/lib/RedisCache.ts
@@ -301,6 +301,28 @@ export class RedisCache extends CacheInstance {
   /**
    * @inheritdoc
    */
+  public async getKeys(pattern: string): Promise<string[]> {
+    try {
+      return await this.getKeysInternal(pattern);
+    } catch (error) {
+      /**
+       * A timeout can occur if the connection was broken during
+       * a value fetching. We don't want to hang forever if this is the case.
+       */
+      this.emit('warn', 'Error while fetching keys from the Redis cache', error);
+      return [];
+    }
+  }
+
+  private async getKeysInternal(pattern: string): Promise<string[]> {
+    const keys = await this.redisClient.keys(pattern);
+    this.emit('get', pattern, keys);
+    return keys;
+  }
+
+  /**
+   * @inheritdoc
+   */
   public async getTtl(key: string): Promise<number | undefined> {
     try {
       const ttl = await this.redisClient.pttl(key);

--- a/src/lib/WriteThroughCache.ts
+++ b/src/lib/WriteThroughCache.ts
@@ -2,12 +2,10 @@ import { CachableValue, CacheInstance } from './CacheInstance';
 import { RedisCache } from './RedisCache';
 import { LocalCache } from './LocalCache';
 
-
 /**
  * Write-through cache, using Redis and a local LRU cache.
  */
 export class WriteThroughCache extends CacheInstance {
-
   private redisCacheForWriting: CacheInstance;
   private redisCacheForReading: CacheInstance;
   private localCache: CacheInstance;
@@ -69,6 +67,13 @@ export class WriteThroughCache extends CacheInstance {
       await this.localCache.setValue(key, redisValue, ttl / 1000);
     }
     return redisValue;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public getKeys(pattern: string): Promise<string[]> {
+    return this.redisCacheForReading.getKeys(pattern);
   }
 
   /**

--- a/test/LocalCache_test.ts
+++ b/test/LocalCache_test.ts
@@ -99,6 +99,30 @@ describe('LocalCache', () => {
     expect(cacheTtl).to.equal(0);
   });
 
+
+  it('should return an array of keys that match the given pattern', async () => {
+    const cache = new LocalCache();
+    cache.setValue('key1', 'value1');
+    cache.setValue('key2', 'value2');
+    cache.setValue('key3', 'value3');
+    cache.setValue('Difff3', 'different');
+
+    const keys = await cache.getKeys('key*');
+
+    expect(keys).to.deep.equal(['key1', 'key2', 'key3']);
+  });
+
+  it('should return an empty array if no keys match the given pattern', async () => {
+    const cache = new LocalCache();
+    cache.setValue('key1', 'value1');
+    cache.setValue('key2', 'value2');
+    cache.setValue('key3', 'value3');
+
+    const keys = await cache.getKeys('nonexistent*');
+
+    expect(keys).to.deep.equal([]);
+  });
+
 });
 
 function sleep(ms: number): Promise<void> {

--- a/test/RedisCache_test.ts
+++ b/test/RedisCache_test.ts
@@ -237,4 +237,29 @@ describe('RedisCache', () => {
       expect(replicationAcknowledged).to.equal(0);
     });
   });
+
+  describe('getKeys', () => {
+    it('should return the keys matching the given pattern', async function (): Promise<void> {
+      if (!process.env.TEST_REDIS_URL) {
+        this.skip();
+      }
+
+      const cache = new RedisCache(process.env.TEST_REDIS_URL as string);
+      await cache.isReady();
+      await cache.clear();
+      
+      await cache.setValue('key1', 'value1');
+      await cache.setValue('key2', 'value');
+      await cache.setValue('key3', 'value');
+      await cache.setValue('randomKey1', 'value');
+      await cache.setValue('randomKey2', 'value');
+
+      const pattern = 'key*';
+      const expectedOutput: string[] = ['key1', 'key2', 'key3'];
+
+      const result = await cache.getKeys(pattern);
+
+      expect(result.sort()).to.deep.equal(expectedOutput);
+    });
+  });
 });

--- a/test/WriteThroughCache_test.ts
+++ b/test/WriteThroughCache_test.ts
@@ -174,4 +174,29 @@ describe('WriteThroughCache', () => {
 
   });
 
+  describe('getKeys', () => {
+    it('should return the keys matching the given pattern', async function (): Promise<void> {
+      if (!process.env.TEST_REDIS_URL) {
+        this.skip();
+      }
+
+      const cache = new WriteThroughCache(process.env.TEST_REDIS_URL as string);
+      await cache.isReady();
+      await cache.clear();
+      
+      await cache.setValue('key1', 'value1');
+      await cache.setValue('key2', 'value');
+      await cache.setValue('key3', 'value');
+      await cache.setValue('randomKey1', 'value');
+      await cache.setValue('randomKey2', 'value');
+
+      const pattern = 'key*';
+      const expectedOutput: string[] = ['key1', 'key2', 'key3'];
+
+      const result = await cache.getKeys(pattern);
+
+      expect(result.sort()).to.deep.equal(expectedOutput);
+    });
+  });
+
 });


### PR DESCRIPTION
## Problem
Having access to the list of keys is important in cases where we want to manipulate the cache such as deletes based on a pattern.

## Solution
Exposing keys function from Redis allow us to find keys matching a certain pattern, thus allowing the dev to seek and delete expected caches.

### Potential issue
Get Keys is O(n), n is the number of keys in cache and locks the instance while looping through all items. A potential solution is to use SCAN instead. But in this case, it will only be used in connectors which won't have a lot of cached items.