### PR TITLE
🧰 [patch] GHA: Fix pr-name events

### DIFF
--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -3,9 +3,8 @@ name: 🚓 PR naming convention
 
 on:
   pull_request:
-    types: [opened, edited]
-    branches:
-      - master
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, master] # keep both for max. copy-pastability
 
 jobs:
   pr_naming_convention:


### PR DESCRIPTION
Events were incorrect and only firing on PR open, detached from any commit and failing to show up as broken :(