### PR TITLE
💨 [minor] WriteThroughCache: Support emitting metrics periodically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cachette",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cachette",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "ioredis": "5.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cachette",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "engines": {
     "node": ">=18",
     "npm": ">=9.5.0"

--- a/src/lib/RedisCache.ts
+++ b/src/lib/RedisCache.ts
@@ -127,7 +127,7 @@ export class RedisCache extends CacheInstance {
    */
   public startConnectionStrategy(): void {
     this.ready = true;
-    this.emit('info', `Connection established to Redis at ${this.url}.`);
+    this.emit('info', `Connection established to Redis at ${this.url}`);
   }
 
   /**


### PR DESCRIPTION
This will let users of cachette.WriteThroughCache get basic cache usage hit/miss data.

We need this to measure whether it's reasonable to switch a certain service back to a
regular RedisCache (if volume is fine), or if we actually need a WriteThroughCache.