### PR TITLE
💡 [patch] Build: no npm audit & fund flags in CI

### DIFF
--- a/.github/workflows/npm-tests.yml
+++ b/.github/workflows/npm-tests.yml
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-${{ env.APPLICATION_NAME }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
       - name: NPM install 📦
         run: |
-          npm ci
+          npm --no-audit --no-fund ci
 
       - name: Run tests ✅
         run: |

--- a/.github/workflows/publish-package-on-merge.yml
+++ b/.github/workflows/publish-package-on-merge.yml
@@ -55,7 +55,7 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-${{ env.APPLICATION_NAME }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
       - name: NPM install 📦
-        run: npm ci
+        run: npm --no-audit --no-fund ci
 
       - name: Pushes the package to NPM
         run: |


### PR DESCRIPTION
We don’t need them during the build, and they can break the build if the GH audit/fund backend is down.